### PR TITLE
Made navigation links respect site.titlecase

### DIFF
--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -16,26 +16,12 @@ single: true
     </p>
     <p class="meta">
       {% if page.previous.url %}
-        <a class="basic-alignment left" 
-           href="{{page.previous.url}}" 
-           title="Previous Post: {%if site.titlecase%}{{page.previous.title|titlecase}}{%else%}{{page.previous.title}}{%endif%}">
-          {% if site.titlecase %}
-            &laquo {{ page.previous.title | titlecase }}
-          {% else %}
-            &laquo {{ page.previous.title }}
-          {% endif %}
-        </a>
+        <a class="basic-alignment left" href="{{page.previous.url}}" 
+           title="Previous Post: {%if site.titlecase%}{{page.previous.title | titlecase}}{%else%}{{page.previous.title}}{%endif%}">&laquo; {%if site.titlecase%}{{page.previous.title | titlecase}}{% else %}{{page.previous.title}}{%endif%}</a>
       {% endif %}
       {% if page.next.url %}
-        <a class="basic-alignment right" 
-           href="{{page.next.url}}" 
-           title="Next Post: {%if site.titlecase%}{{page.next.title|titlecase}}{%else%}{{page.next.title}}{%endif%}">
-          {% if site.titlecase %}
-            {{ page.next.title | titlecase }} &raquo;
-          {% else %}
-            {{ page.next.title }} &raquo;
-          {% endif %}
-        </a>
+        <a class="basic-alignment right" href="{{page.next.url}}" 
+           title="Next Post: {%if site.titlecase%}{{page.next.title | titlecase}}{%else%}{{page.next.title}}{%endif%}">{%if site.titlecase%}{{page.next.title | titlecase}}{%else%}{{page.next.title}}{%endif%} &raquo;</a>
       {% endif %}
     </p>
   </footer>


### PR DESCRIPTION
Currently navigation links do not care about the value of `site.titlecase` which looks wrong.

I added a few `{% if %}` to handle that in post layout.
