### PR TITLE
Excerpted posts in atom.xml

### DIFF
--- a/source/atom.xml
+++ b/source/atom.xml
@@ -21,7 +21,7 @@ layout: nil
     <link href="{{ site.url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ site.url }}{{ post.id }}</id>
-    <content type="html"><![CDATA[{{ post.content | expand_urls: site.url | cdata_escape }}]]></content>
+    <content type="html"><![CDATA[{{ post.content | excerpt | expand_urls: site.url | cdata_escape }}]]></content>
   </entry>
   {% endfor %}
 </feed>


### PR DESCRIPTION
It seems that atom.xml should provide posts excerpted (just as they look on the main page of blog). This change fixes that
